### PR TITLE
Query Treasury Wallet

### DIFF
--- a/api/src/entities/treasuries.rs
+++ b/api/src/entities/treasuries.rs
@@ -26,6 +26,20 @@ impl Model {
 
         wallets_loader.load_one(self.id).await
     }
+
+    async fn wallet(
+        &self,
+        ctx: &Context<'_>,
+        asset_type: wallets::AssetType,
+    ) -> Result<Option<wallets::Model>> {
+        let AppContext { wallets_loader, .. } = ctx.data::<AppContext>()?;
+
+        let wallets = wallets_loader.load_one(self.id).await?.unwrap_or_default();
+
+        Ok(wallets
+            .into_iter()
+            .find(|wallet| wallet.asset_id == asset_type))
+    }
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/api/src/mutations/vault.rs
+++ b/api/src/mutations/vault.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use async_graphql::{Context, Error, InputObject, Object, Result, SimpleObject};
 use fireblocks::{objects::vault::CreateVaultWallet, Client as FireblocksClient};
 use hub_core::producer::Producer;


### PR DESCRIPTION
## Changes
- Helper query to find a single wallet by asset_type used wallets_loader so not more efficient but convenient for clients